### PR TITLE
Correct 2x invalid trailing commas in JS functions params

### DIFF
--- a/js/Facebook/AdsExtension/Adminhtml/fae.js
+++ b/js/Facebook/AdsExtension/Adminhtml/fae.js
@@ -300,7 +300,7 @@ var FAEFlowContainer = React.createClass({
         React.createElement(
           'div',
           {style: {color: 'black'}, align: 'left'},
-          this.state.exceptionTrace,
+          this.state.exceptionTrace
         )
       );
     }
@@ -399,7 +399,7 @@ var displayFBModal = function displayFBModal() {
         diaFlow.removeChild(diaFlow.firstChild);
         ReactDOM.render(
           warning,
-          diaFlow,
+          diaFlow
         );
         ReactDOM.render(
           warning,


### PR DESCRIPTION
Correct invalid syntax in `js/Facebook/AdsExtension/Adminhtml/fae.js`