### PR TITLE
Removed the wrong double quotes facebook_ads_extension base layout

### DIFF
--- a/app/design/frontend/base/default/layout/facebook_ads_extension.xml
+++ b/app/design/frontend/base/default/layout/facebook_ads_extension.xml
@@ -7,7 +7,7 @@
              template="facebook_ads_extension/head.phtml" />
       <block type="Facebook_AdsExtension/addToCart"
              name="facebook_ads_extension.addtocart"
-             template="facebook_ads_extension/addtocart.phtml" />"
+             template="facebook_ads_extension/addtocart.phtml" />
     </reference>
   </default>
   <cms_index_index>


### PR DESCRIPTION
In the base layout, we have a double quote by mistake, so it is a quick fix.

Raf.