### PR TITLE
Removing unnecessary file inclusion and using Magento's built in meth…

### DIFF
--- a/app/code/community/Facebook/AdsExtension/Block/AddToCart.php
+++ b/app/code/community/Facebook/AdsExtension/Block/AddToCart.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_AddToCart
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Block/Adminhtml/Diaindex.php
+++ b/app/code/community/Facebook/AdsExtension/Block/Adminhtml/Diaindex.php
@@ -8,18 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/Feedindex.php')) {
-  include_once 'Feedindex.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_Adminhtml_Feedindex.php';
-}
-
-if (file_exists(__DIR__.'/Pixelindex.php')) {
-  include_once 'Pixelindex.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_Adminhtml_Pixelindex.php';
-}
-
 if (file_exists(__DIR__.'/../../lib/fb.php')) {
   include_once __DIR__.'/../../lib/fb.php';
 } else {
@@ -34,14 +22,14 @@ class Facebook_AdsExtension_Block_Adminhtml_Diaindex
 
   private function getPixelindex() {
     if ($this->pixelIndex == null) {
-      $this->pixelIndex = new Facebook_AdsExtension_Block_Adminhtml_Pixelindex();
+      $this->pixelIndex = Mage::getBlockSingleton('Facebook_AdsExtension/adminhtml_pixelindex');
     }
     return $this->pixelIndex;
   }
 
   private function getFeedindex() {
     if ($this->feedIndex == null) {
-      $this->feedIndex = new Facebook_AdsExtension_Block_Adminhtml_Feedindex();
+      $this->feedIndex = Mage::getBlockSingleton('Facebook_AdsExtension/adminhtml_feedindex');
     }
     return $this->feedIndex;
   }
@@ -121,10 +109,10 @@ class Facebook_AdsExtension_Block_Adminhtml_Diaindex
 
   public function fetchFeedSamples() {
     $ob = Mage::getModel('Facebook_AdsExtension/observer');
-    $obins = new $ob;
+
     FacebookAdsExtension::setErrorLogging();
     try {
-      $productSamples = $obins->generateFacebookProductSamples();
+      $productSamples = $ob->generateFacebookProductSamples();
       return $productSamples;
     } catch (Exception $e) {
       return $e->getMessage()." : ".$e->getTraceAsString();
@@ -148,7 +136,7 @@ class Facebook_AdsExtension_Block_Adminhtml_Diaindex
     $feed_setup = $this->getFeedIndex()->fetchFeedSetupEnabled();
     if (!$feed_setup) {
       Mage::getModel('core/config')->saveConfig(
-        FBProductFeed::PATH_FACEBOOK_ADSEXTENSION_FEED_GENERATION_ENABLED,
+          Facebook_AdsExtension_Model_FBProductFeed::PATH_FACEBOOK_ADSEXTENSION_FEED_GENERATION_ENABLED,
         true);
       return true;
     }

--- a/app/code/community/Facebook/AdsExtension/Block/Adminhtml/Feedindex.php
+++ b/app/code/community/Facebook/AdsExtension/Block/Adminhtml/Feedindex.php
@@ -14,12 +14,6 @@ if (file_exists(__DIR__.'/../../lib/fb.php')) {
   include_once 'Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/../../Model/FBProductFeed.php')) {
-  include_once __DIR__.'/../../Model/FBProductFeed.php';
-} else {
-  include_once 'Facebook_AdsExtension_Model_FBProductFeed.php';
-}
-
 class Facebook_AdsExtension_Block_Adminhtml_Feedindex
   extends Mage_Adminhtml_Block_Template {
 
@@ -43,12 +37,12 @@ class Facebook_AdsExtension_Block_Adminhtml_Feedindex
   }
 
   public function fetchFeedSetupEnabled() {
-    $setup = FBProductFeed::getCurrentSetup();
+    $setup = Facebook_AdsExtension_Model_FBProductFeed::getCurrentSetup();
     return $setup['enabled'];
   }
 
   public function fetchFeedSetupFormat() {
-    $setup = FBProductFeed::getCurrentSetup();
+    $setup = Facebook_AdsExtension_Model_FBProductFeed::getCurrentSetup();
     return $setup['format'];
   }
 }

--- a/app/code/community/Facebook/AdsExtension/Block/Head.php
+++ b/app/code/community/Facebook/AdsExtension/Block/Head.php
@@ -8,11 +8,5 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_Head extends Facebook_AdsExtension_Block_Common {
 }

--- a/app/code/community/Facebook/AdsExtension/Block/InitiateCheckout.php
+++ b/app/code/community/Facebook/AdsExtension/Block/InitiateCheckout.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_InitiateCheckout
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Block/MessengerChat.php
+++ b/app/code/community/Facebook/AdsExtension/Block/MessengerChat.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_MessengerChat
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Block/Purchase.php
+++ b/app/code/community/Facebook/AdsExtension/Block/Purchase.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_Purchase
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Block/Search.php
+++ b/app/code/community/Facebook/AdsExtension/Block/Search.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_Search
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Block/ViewCategory.php
+++ b/app/code/community/Facebook/AdsExtension/Block/ViewCategory.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_ViewCategory
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Block/ViewContent.php
+++ b/app/code/community/Facebook/AdsExtension/Block/ViewContent.php
@@ -8,12 +8,6 @@
  * of patent rights can be found in the PATENTS file in the code directory.
  */
 
-if (file_exists(__DIR__.'/common.php')) {
-  include_once 'common.php';
-} else {
-  include_once 'Facebook_AdsExtension_Block_common.php';
-}
-
 class Facebook_AdsExtension_Block_ViewContent
   extends Facebook_AdsExtension_Block_Common {
 

--- a/app/code/community/Facebook/AdsExtension/Model/FBDebugProduct.php
+++ b/app/code/community/Facebook/AdsExtension/Model/FBDebugProduct.php
@@ -15,7 +15,7 @@ if (file_exists(__DIR__.'/../lib/fb.php')) {
 }
 
 // Wrapper class for Magento's Product for Debugging
-class FBDebugProduct {
+class Facebook_AdsExtension_Model_FBDebugProduct {
   public function __construct($product, $count, $debug_origin = null) {
     $this->product = $product;
     $this->name = "Product $count";

--- a/app/code/community/Facebook/AdsExtension/Model/FBProductFeed.php
+++ b/app/code/community/Facebook/AdsExtension/Model/FBProductFeed.php
@@ -14,7 +14,7 @@ if (file_exists(__DIR__.'/../lib/fb.php')) {
   include_once 'Facebook_AdsExtension_lib_fb.php';
 }
 
-class FBProductFeed {
+class Facebook_AdsExtension_Model_FBProductFeed {
 
   const ATTR_ID = 'id';
   const ATTR_TITLE = 'title';

--- a/app/code/community/Facebook/AdsExtension/Model/FBProductFeedSamples.php
+++ b/app/code/community/Facebook/AdsExtension/Model/FBProductFeedSamples.php
@@ -124,7 +124,7 @@ class Facebook_AdsExtension_Model_FBProductFeedSamples extends Facebook_AdsExten
     } else {
       include_once 'Facebook_AdsExtension_Model_FBDebugProduct.php';
     }
-    $product2 = Mage::getModel('Facebook_AdsExtension/fBProductFeed', [$product, $count, $this]);
+    $product2 = new Facebook_AdsExtension_Model_FBDebugProduct($product, $count, $this);
     $this->logd("Fetch Stock Item of Product $count");
     $this->stock = Mage::getModel('cataloginventory/stock_item')->loadByProduct($product);
     $this->logd("Build Product Entry of Product $count");

--- a/app/code/community/Facebook/AdsExtension/Model/FBProductFeedSamples.php
+++ b/app/code/community/Facebook/AdsExtension/Model/FBProductFeedSamples.php
@@ -14,13 +14,7 @@ if (file_exists(__DIR__.'/../lib/fb.php')) {
   include_once 'Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/FBProductFeed.php')) {
-  include_once 'FBProductFeed.php';
-} else {
-  include_once 'Facebook_AdsExtension_Model_FBProductFeed.php';
-}
-
-class FBProductFeedSamples extends FBProductFeed {
+class Facebook_AdsExtension_Model_FBProductFeedSamples extends Facebook_AdsExtension_Model_FBProductFeed {
   public $debug_mode = false;
    // TODO : Print stacktrace in verbose mode on every log line.
   public $verbose = false;
@@ -130,7 +124,7 @@ class FBProductFeedSamples extends FBProductFeed {
     } else {
       include_once 'Facebook_AdsExtension_Model_FBDebugProduct.php';
     }
-    $product2 = new FBDebugProduct($product, $count, $this);
+    $product2 = Mage::getModel('Facebook_AdsExtension/fBProductFeed', [$product, $count, $this]);
     $this->logd("Fetch Stock Item of Product $count");
     $this->stock = Mage::getModel('cataloginventory/stock_item')->loadByProduct($product);
     $this->logd("Build Product Entry of Product $count");

--- a/app/code/community/Facebook/AdsExtension/Model/FBProductFeedTSV.php
+++ b/app/code/community/Facebook/AdsExtension/Model/FBProductFeedTSV.php
@@ -14,13 +14,7 @@ if (file_exists(__DIR__.'/../lib/fb.php')) {
   include_once 'Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/FBProductFeed.php')) {
-  include_once 'FBProductFeed.php';
-} else {
-  include_once 'Facebook_AdsExtension_Model_FBProductFeed.php';
-}
-
-class FBProductFeedTSV extends FBProductFeed {
+class Facebook_AdsExtension_Model_FBProductFeedTSV extends Facebook_AdsExtension_Model_FBProductFeed {
 
   const TSV_FEED_FILENAME = 'facebook_adstoolbox_product_feed.tsv';
 

--- a/app/code/community/Facebook/AdsExtension/Model/FBProductFeedXML.php
+++ b/app/code/community/Facebook/AdsExtension/Model/FBProductFeedXML.php
@@ -14,13 +14,7 @@ if (file_exists(__DIR__.'/../lib/fb.php')) {
   include_once 'Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/FBProductFeed.php')) {
-  include_once 'FBProductFeed.php';
-} else {
-  include_once 'Facebook_AdsExtension_Model_FBProductFeed.php';
-}
-
-class FBProductFeedXML extends FBProductFeed {
+class Facebook_AdsExtension_Model_FBProductFeedXML extends Facebook_AdsExtension_Model_FBProductFeed {
 
   const XML_FEED_FILENAME = 'facebook_adstoolbox_product_feed.xml';
 

--- a/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php
+++ b/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbdebugController.php
@@ -14,12 +14,6 @@ if (file_exists(__DIR__.'/../../lib/fb.php')) {
   include_once __DIR__.'/../../../../Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/../../Model/FBProductFeedSamples.php')) {
-  include_once __DIR__.'/../../Model/FBProductFeedSamples.php';
-} else {
-  include_once 'Facebook_AdsExtension_Model_FBProductFeedSamples.php';
-}
-
 class Facebook_AdsExtension_Adminhtml_FbdebugController
   extends Mage_Adminhtml_Controller_Action {
 
@@ -50,7 +44,7 @@ class Facebook_AdsExtension_Adminhtml_FbdebugController
     if ($this->getRequest()->getParam('debugfeedsamples')) {
       FacebookAdsExtension::setDebugMode(true);
       FacebookAdsExtension::setErrorLogging();
-      $samples = new FBProductFeedSamples();
+      $samples = Mage::getModel('Facebook_AdsExtension/fBProductFeedSamples');
       try {
         $samples = $samples->generate();
         FacebookAdsExtension::setDebugMode(false);

--- a/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbfeedController.php
+++ b/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbfeedController.php
@@ -14,14 +14,6 @@ if (file_exists(__DIR__.'/../../lib/fb.php')) {
   include_once __DIR__.'/../../../../Facebook_AdsExtension_lib_fb.php';
 }
 
-if (file_exists(__DIR__.'/../../Model/FBProductFeed.php')) {
-  include_once __DIR__.'/../../Model/FBProductFeed.php';
-} else if (file_exists(__DIR__.'/../../../../Facebook_AdsExtension_Model_FBProductFeed.php')) {
-  include_once __DIR__.'/../../../../Facebook_AdsExtension_Model_FBProductFeed.php';
-} else {
-  include_once 'Facebook_AdsExtension_Model_FBProductFeed.php';
-}
-
 class Facebook_AdsExtension_Adminhtml_FbfeedController
   extends Mage_Adminhtml_Controller_Action {
 
@@ -83,13 +75,13 @@ class Facebook_AdsExtension_Adminhtml_FbfeedController
 
     if ($enabled) {
       Mage::getModel('core/config')->saveConfig(
-        FBProductFeed::PATH_FACEBOOK_ADSEXTENSION_FEED_GENERATION_ENABLED,
+          Facebook_AdsExtension_Model_FBProductFeed::PATH_FACEBOOK_ADSEXTENSION_FEED_GENERATION_ENABLED,
         ($enabled === 'true'));
     }
 
     if ($format) {
       Mage::getModel('core/config')->saveConfig(
-        FBProductFeed::PATH_FACEBOOK_ADSEXTENSION_FEED_GENERATION_FORMAT,
+          Facebook_AdsExtension_Model_FBProductFeed::PATH_FACEBOOK_ADSEXTENSION_FEED_GENERATION_FORMAT,
         $format);
     }
 
@@ -102,11 +94,11 @@ class Facebook_AdsExtension_Adminhtml_FbfeedController
     $response = array(
       'success' => true,
     );
-    $logfile = Mage::getBaseDir('log').'/'.FBProductFeed::LOGFILE;
+    $logfile = Mage::getBaseDir('log'). DS .Facebook_AdsExtension_Model_FBProductFeed::LOGFILE;
     $fp = fopen($logfile, 'r');
     if (!$fp) {
       $response['lastrunlogs'] =
-        'Read '.FBProductFeed::LOGFILE.' error!';
+        'Read '.Facebook_AdsExtension_Model_FBProductFeed::LOGFILE.' error!';
       $this->ajaxSend($response);
       return;
     }

--- a/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbregenController.php
+++ b/app/code/community/Facebook/AdsExtension/controllers/Adminhtml/FbregenController.php
@@ -37,8 +37,7 @@ class Facebook_AdsExtension_Adminhtml_FbregenController
   private function doRegenerateitnow($request, $response) {
     $ob = Mage::getModel('Facebook_AdsExtension/observer');
     $use_cache = $request->getPost('useCache', false);
-    $obins = new $ob;
-    $obins->internalGenerateFBProductFeed(false, $use_cache);
+    $ob->internalGenerateFBProductFeed(false, $use_cache);
 
     $this->ajaxSend(array(
       'success' => true,


### PR DESCRIPTION
…ods to load required models and blocks

Magento isn't meant to be filled with `include_once`, I have gone through the module, fixed class name declarations to be compatible with Magento, and modified functions to use Magento's `Mage::getMethod()`, `Mage::getBlockSingleton()` where necessary