### PR TITLE
Bugfix to work correctly with stores

### DIFF
--- a/app/code/community/Facebook/AdsExtension/Block/Common.php
+++ b/app/code/community/Facebook/AdsExtension/Block/Common.php
@@ -45,7 +45,13 @@ class Facebook_AdsExtension_Block_Common extends Mage_Core_Block_Template {
   }
 
   public function getFacebookPixelID() {
-    return Mage::getStoreConfig('facebook_ads_toolbox/fbpixel/id');
+    $storeId = Mage::app()->getStore()->getStoreId();
+    $facebookStoreId = $this->getFacebookStoreID();
+    return ($storeId == $facebookStoreId) ? Mage::getStoreConfig('facebook_ads_toolbox/fbpixel/id') : null;
+  }
+
+  public function getFacebookStoreID() {
+    return Mage::getStoreConfig('facebook_ads_toolbox/fbstore/id');
   }
 
   public function pixelInitCode() {


### PR DESCRIPTION
Without this patch, the Facebook Ads block will be put in all Magento stores even if  the merchant chooses a specific store.